### PR TITLE
Fix warning in generate.cc

### DIFF
--- a/scripts/generate.cc
+++ b/scripts/generate.cc
@@ -154,7 +154,7 @@ void print_expression(FILE *f, int budget, uint32_t mask, bool avoid_undef, bool
 		return;
 	}
 
-	while ((mask & ~((~0) << num_modes)) == 0)
+	while ((mask & ~((~0U) << num_modes)) == 0)
 		mask = xorshift32() & (in_param ? ~4 : ~0);
 
 	if ((mask & 3) != 0)


### PR DESCRIPTION
Hi there!

This commit proposes to fix the warning:
```
scripts/generate.cc: In function ‘void print_expression(FILE*, int, uint32_t, bool, bool, bool)’:
scripts/generate.cc:157:31: warning: left shift of negative value [-Wshift-negative-value]
  157 |         while ((mask & ~((~0) << num_modes)) == 0)
      |                          ~~~~~^~~~~~~~~~~~
```
that I got when using g++.

Thank you!
Flavien